### PR TITLE
Update imports to support newer versions of ember

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,10 +13,10 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
 
-    this.app.import('vendor/css/material-icons.css');
-    this.app.import('vendor/fonts/MaterialIcons-Regular.eot', { destDir: 'fonts' });
-    this.app.import('vendor/fonts/MaterialIcons-Regular.svg', { destDir: 'fonts' });
-    this.app.import('vendor/fonts/MaterialIcons-Regular.ttf', { destDir: 'fonts' });
-    this.app.import('vendor/fonts/MaterialIcons-Regular.woff', { destDir: 'fonts' });
+    app.import('vendor/css/material-icons.css');
+    app.import('vendor/fonts/MaterialIcons-Regular.eot', { destDir: 'fonts' });
+    app.import('vendor/fonts/MaterialIcons-Regular.svg', { destDir: 'fonts' });
+    app.import('vendor/fonts/MaterialIcons-Regular.ttf', { destDir: 'fonts' });
+    app.import('vendor/fonts/MaterialIcons-Regular.woff', { destDir: 'fonts' });
   }
 };


### PR DESCRIPTION
I decided to upgrade to ember cli 3.0.0, during the build process it kept on giving me this error:

```
ERROR Summary:

  - broccoliBuilderErrorStack: [undefined]
  - codeFrame: [undefined]
  - errorMessage: Cannot read property 'import' of undefined
  - errorType: [undefined]
  - location:
    - column: [undefined]
    - file: [undefined]
    - line: [undefined]
  - message: Cannot read property 'import' of undefined
  - name: TypeError
  - nodeAnnotation: [undefined]
  - nodeName: [undefined]
  - originalErrorMessage: [undefined]
  - stack: TypeError: Cannot read property 'import' of undefined
    at Class.included (/.../node_modules/ember-cli-material-design-icons/index.js:16:14)
```

by replacing `this.app` just for `app` it fixed the issue and it still adds the vendor fonts.